### PR TITLE
Remove size limitation from constraint fields of the query table

### DIFF
--- a/gb-backend/grails-app/domain/nl/thehyve/gb/backend/Query.groovy
+++ b/gb-backend/grails-app/domain/nl/thehyve/gb/backend/Query.groovy
@@ -33,14 +33,14 @@ class Query {
         name maxSize: 1000
         type maxSize: 255, nullable: false
         username maxSize: 50
-        queryConstraint nullable: false
+        queryConstraint type: 'text', nullable: false
         bookmarked nullable: true
         subscribed nullable: true
         subscriptionFreq nullable: true
         deleted nullable: true
         createDate nullable: true
         updateDate nullable: true
-        queryBlob nullable: true
+        queryBlob type: 'text', nullable: true
     }
 
 }


### PR DESCRIPTION
By default strings are converted to `character varying(255)`, for constraint containing fields it is not enough. 