### PR TITLE
Ensure audience validation on access token

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,13 @@ Before using the command you have to substitute words in uppercase with proper o
 
 The value of the `refresh_token` field in the response is the offline token.
 
+### Audience Support
+
+The application checks audience on the access token - verifies if the audience field contains the Keycloak client ID.
+In Keyclaok versions <= 4.5.0 client ID in access token audience field is always included by default. 
+For newer versions of Keycloak the client has to be configured to include it. Follow [the official instruction](https://www.keycloak.org/docs/4.8/server_admin/#_audience_hardcoded) to hardcode the 
+audience for the client.
+
 ## API calls:
 
 - GET `/queries`

--- a/gb-backend/grails-app/conf/application.yml
+++ b/gb-backend/grails-app/conf/application.yml
@@ -139,6 +139,8 @@ keycloak:
     bearer-only: true
     # Important for parsing roles correctly
     use-resource-role-mappings: true
+    # Ensure audience field validation on the access token (by default not verified)
+    verify-token-audience: true
 
 environments:
     development:


### PR DESCRIPTION
According to OIDC specification: "The Client MUST validate that the aud (audience) Claim contains its client_id value registered at the Issuer identified by the iss (issuer) Claim as an audience."

Related ticket: [TMT-383](https://jira.thehyve.nl/browse/TMT-838)